### PR TITLE
Update to preserve media queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 npm-debug.log
+node_modules

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var prettify = require('gulp-prettify');
 var fs = require('fs');
 var siphon = require('siphon-media-query');
 var lazypipe = require('lazypipe');
-var inlineCss = require('gulp-inline-css');
+var juice = require('premailer-gulp-juice');
 var htmlmin = require('gulp-htmlmin');
 var injectString = require('gulp-inject-string');
 
@@ -32,7 +32,7 @@ Elixir.extend('processEmails', function(options) {
 
         var pipe = lazypipe()
             .pipe(injectString.replace, '<!-- <style> -->', '<style>'+css+'</style>')
-            .pipe(inlineCss)
+            .pipe(juice(options.juice))
             .pipe(htmlmin, {
                 collapseWhitespace: true,
                 minifyCSS: true

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ Elixir.extend('processEmails', function(options) {
 
         var pipe = lazypipe()
             .pipe(injectString.replace, '<!-- <style> -->', '<style>'+css+'</style>')
-            .pipe(inlineCss({ preserveMediaQueries: true }))
+            .pipe(inlineCss, { preserveMediaQueries: true })
             .pipe(htmlmin, {
                 collapseWhitespace: true,
                 minifyCSS: true

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var prettify = require('gulp-prettify');
 var fs = require('fs');
 var siphon = require('siphon-media-query');
 var lazypipe = require('lazypipe');
-var juice = require('premailer-gulp-juice');
+var inlineCss = require('gulp-inline-css');
 var htmlmin = require('gulp-htmlmin');
 var injectString = require('gulp-inject-string');
 
@@ -32,7 +32,7 @@ Elixir.extend('processEmails', function(options) {
 
         var pipe = lazypipe()
             .pipe(injectString.replace, '<!-- <style> -->', '<style>'+css+'</style>')
-            .pipe(juice(options.juice))
+            .pipe(inlineCss({ preserveMediaQueries: true }))
             .pipe(htmlmin, {
                 collapseWhitespace: true,
                 minifyCSS: true

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
   "dependencies": {
     "gulp-htmlmin": "^2.0.0",
     "gulp-inject-string": "^1.1.0",
-    "gulp-inline-css": "^3.1.0",
     "gulp-prettify": "^0.4.0",
     "inky": "^1.3.5",
     "lazypipe": "^1.0.1",
+    "premailer-gulp-juice": "^0.1.7",
     "siphon-media-query": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
   "dependencies": {
     "gulp-htmlmin": "^2.0.0",
     "gulp-inject-string": "^1.1.0",
+    "gulp-inline-css": "^3.1.0",
     "gulp-prettify": "^0.4.0",
     "inky": "^1.3.5",
     "lazypipe": "^1.0.1",
-    "premailer-gulp-juice": "^0.1.7",
     "siphon-media-query": "^1.0.0"
   }
 }


### PR DESCRIPTION
We needed responsive emails using Zurb's inky and I noticed this library doesn't preserve them.
Was going to move over to juice, but ended up just adding the preserve email option in inlineCSS.